### PR TITLE
Add a congestion check as implemented in Logstash Redis output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 moaikids
 HANAI Tohru aka pokehanai
+maxgutman

--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ Currently the plugin supports following Redis commands:
 
 #### _key_ string for Redis storage
 
-Redis commands require _key_ and _value_.  
+Redis commands require _key_ and _value_.
 For _key_, the plugin supports either way;
 
-1. Specify a fixed key.  
+1. Specify a fixed key.
    You can do this simply using `key` option in td-agent configuration file.
 
    ```apache
    type redis_store
    key userdata
    ```
-   
-2. Lookup a key string in every event data by a lookup path.  
+
+2. Lookup a key string in every event data by a lookup path.
    If event data have structured data like
 
    ```javascript
@@ -75,9 +75,9 @@ With the previous data, _key_ will be `outuser.Kei.accesslog`.
 
 To determine what _value_ in every event data to be srtored, you have two options;
 
-1. Store extracted data in event data, by a lookup path with `value_path` option.  
+1. Store extracted data in event data, by a lookup path with `value_path` option.
    It works like `key_path`.
-2. Store whole data.  
+2. Store whole data.
    This is default behavior. To do it, simply omit `value_path` option.
 
 Installation
@@ -123,9 +123,13 @@ No more options than common options.
 
 ### `list` storage specific options
 
-| Key     | Type   | Default                  | Description                         |
-| :----   | :----- | :----------------------- | :------------                       |
-| `order` | string | asc                      | `asc`: **rpush**, `desc`: **lpush** |
+| Key                    | Type    | Default                  | Description                                            |
+| :----                  | :-----  | :----------------------- | :------------                                          |
+| `order`                | string  | asc                      | `asc`: **rpush**, `desc`: **lpush**                    |
+| `congestion_threshold` | integer | 0                        | see Note below                                         |
+| `congestion_interval`  | integer | 1                        | How often to check for congestion. Default is 1 second |
+
+Note: In case Redis data_type is “list” and has more than @congestion_threshold items, block until someone consumes them and reduces congestion, otherwise if there are no consumers Redis will run out of memory, unless it was configured with OOM protection. But even with OOM protection, a single Redis list can block all other users of Redis, until Redis CPU consumption reaches the max allowed RAM size. A default value of 0 means that this limit is disabled. Only supported for list Redis data_type.
 
 ### `set` storage specific options
 
@@ -149,8 +153,8 @@ No more options than common options.
 Copyright
 ---------
 
-Copyright (c) 2013 moaikids  
-Copyright (c) 2014 HANAI Tohru  
+Copyright (c) 2013 moaikids
+Copyright (c) 2014 HANAI Tohru
 
 License
 -------

--- a/fluent-plugin-redis-store.gemspec
+++ b/fluent-plugin-redis-store.gemspec
@@ -2,8 +2,8 @@
 Gem::Specification.new do |gem|
     gem.name        = "fluent-plugin-redis-store"
     gem.email       = "hanai@pokelabo.co.jp"
-    gem.version     = "0.1.1"
-    gem.authors     = ["moaikids", "HANAI Tohru aka pokehanai"]
+    gem.version     = "0.1.2"
+    gem.authors     = ["moaikids", "HANAI Tohru aka pokehanai", "mxgutman"]
     gem.licenses    = ["Apache License Version 2.0"]
     gem.summary     = %q{Redis(zset/set/list/string/publish) output plugin for Fluentd}
     gem.description = %q{Redis(zset/set/list/string/publish) output plugin for Fluentd...}

--- a/lib/fluent/plugin/out_redis_store.rb
+++ b/lib/fluent/plugin/out_redis_store.rb
@@ -3,26 +3,28 @@ module Fluent
     Fluent::Plugin.register_output('redis_store', self)
 
     # redis connection
-    config_param :host,      :string,  :default => '127.0.0.1'
-    config_param :port,      :integer, :default => 6379
-    config_param :path,      :string,  :default => nil
-    config_param :password,  :string,  :default => nil
-    config_param :db,        :integer, :default => 0
-    config_param :timeout,   :float,   :default => 5.0
+    config_param :host,                 :string,  :default => '127.0.0.1'
+    config_param :port,                 :integer, :default => 6379
+    config_param :path,                 :string,  :default => nil
+    config_param :password,             :string,  :default => nil
+    config_param :db,                   :integer, :default => 0
+    config_param :timeout,              :float,   :default => 5.0
 
     # redis command and parameters
-    config_param :format_type,  :string,  :default => 'json'
-    config_param :store_type,   :string,  :default => 'zset'
-    config_param :key_prefix,   :string,  :default => ''
-    config_param :key_suffix,   :string,  :default => ''
-    config_param :key,          :string,  :default => nil
-    config_param :key_path,     :string,  :default => nil
-    config_param :score_path,   :string,  :default => nil
-    config_param :value_path,   :string,  :default => ''
-    config_param :key_expire,   :integer, :default => -1
-    config_param :value_expire, :integer, :default => -1
-    config_param :value_length, :integer, :default => -1
-    config_param :order,        :string,  :default => 'asc'
+    config_param :format_type,          :string,  :default => 'json'
+    config_param :store_type,           :string,  :default => 'zset'
+    config_param :key_prefix,           :string,  :default => ''
+    config_param :key_suffix,           :string,  :default => ''
+    config_param :key,                  :string,  :default => nil
+    config_param :key_path,             :string,  :default => nil
+    config_param :score_path,           :string,  :default => nil
+    config_param :value_path,           :string,  :default => ''
+    config_param :key_expire,           :integer, :default => -1
+    config_param :value_expire,         :integer, :default => -1
+    config_param :value_length,         :integer, :default => -1
+    config_param :order,                :string,  :default => 'asc'
+    config_param :congestion_threshold, :integer, :default => 0
+    config_param :congestion_interval,  :integer, :default => 1
 
     def initialize
       super
@@ -32,7 +34,6 @@ module Fluent
 
     def configure(conf)
       super
-
       if @key_path == nil and @key == nil
         raise Fluent::ConfigError, "either key_path or key is required"
       end
@@ -47,6 +48,8 @@ module Fluent
         @redis = Redis.new(:host => @host, :port => @port, :password => @password,
                            :timeout => @timeout, :thread_safe => true, :db => @db)
       end
+      @congestion_check_times = Hash.new {
+              |h,k| h[k] = Time.now.to_i - @congestion_interval }
     end
 
     def shutdown
@@ -57,7 +60,30 @@ module Fluent
       [tag, time, record].to_msgpack
     end
 
+    def congestion_check(key)
+      return if @congestion_threshold == 0
+      # Check congestion only if enough time has passed since last check
+      if (Time.now.to_i - @congestion_check_times[key]) >= @congestion_interval
+        # Don't push event to Redis key which has reached @congestion_threshold
+        while @redis.llen(key) >= @congestion_threshold
+          log.warn "Redis key size has hit a congestion threshold " \
+            "#{@congestion_threshold} suspending output for " \
+            "#{@congestion_interval} seconds"
+          sleep @congestion_interval
+        end
+        @congestion_check_time = Time.now.to_i
+      end
+    end
+
     def write(chunk)
+      # For lists where key is predefined, perform a naive congestion check
+      # before buffering over chunks of messages. The check is placed here
+      # primarily to get around @redis.llen cmd not being ready inside pipeline
+      # Downside is that you may exceed congestion_threshold by messages length -1
+      if @key and @store_type == 'list'
+        congestion_check(@key)
+      end
+
       @redis.pipelined {
         chunk.open { |io|
           begin

--- a/test/plugin/test_out_redis_publish.rb
+++ b/test/plugin/test_out_redis_publish.rb
@@ -92,6 +92,8 @@ class RedisStoreOutputTest < Test::Unit::TestCase
     assert_equal -1, d.instance.value_expire
     assert_equal -1, d.instance.value_length
     assert_equal 'asc', d.instance.order
+    assert_equal 0, d.instance.congestion_threshold
+    assert_equal 1, d.instance.congestion_interval
   end
 
   def test_configure_host_port_db


### PR DESCRIPTION
A congestion check prevents OOM errors when Redis is used as a broker/queue (list type). RedisStoreOutput will sleep until the list length is smaller than the specified threshold value. Ideally this check would happen prior to each message being pushed, but this can't happen during pipelining. Instead, the check happens for each chunk and there is a possibility of going above the threshold by the <number of messages in a chunk> -1. Even so, this is still a very useful implementation that was taken from Logstash.
