### PR TITLE
Fix eval methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Configuration
 | `store_type`  | string | zset                     | `string`/`list`/`set`/`zset`/`publish`               |
 | `format_type` | string | plain                    | format type for _value_ (`plain`/`json`/`msgpack`)   |
 | `key_expire`  | int    | -1                       | If set, the key will be expired in specified seconds |
+| `value_lenth` | int    | -1                       | The list or zset should be limit in specified number |
 
 Note: either `key` or `key_path` is required.
 
@@ -144,6 +145,12 @@ based on *timestamp* and it deletes expired _members_ every after new event data
 ### `publish` storage specific options
 
 No more options than common options.
+
+#### How to test
+You should add test case in test/*.rb
+And run below command
+
+> bundle exec ruby *.rb
 
 
 Copyright

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Configuration
 | `store_type`  | string | zset                     | `string`/`list`/`set`/`zset`/`publish`               |
 | `format_type` | string | plain                    | format type for _value_ (`plain`/`json`/`msgpack`)   |
 | `key_expire`  | int    | -1                       | If set, the key will be expired in specified seconds |
-| `value_lenth` | int    | -1                       | The list or zset should be limit in specified number |
+| `value_length`| int    | -1                       | List or zset should be limited in the specified number |
 
 Note: either `key` or `key_path` is required.
 
@@ -147,10 +147,8 @@ based on *timestamp* and it deletes expired _members_ every after new event data
 No more options than common options.
 
 #### How to test
-You should add test case in test/*.rb
-And run below command
-
-> bundle exec ruby *.rb
+> cd test/plugin
+> bundle exec ruby test_out_redis_publish.rb
 
 
 Copyright

--- a/test/plugin/test_out_redis_publish.rb
+++ b/test/plugin/test_out_redis_publish.rb
@@ -267,32 +267,6 @@ class RedisStoreOutputTest < Test::Unit::TestCase
     assert_equal message, $message
   end
 
-  def test_list_desc_with_value_limitation
-    config = %[
-      format_type plain
-      store_type list
-      key_path   stat
-      order      desc
-      value_length 3
-    ]
-    d = create_driver(config)
-    message = {
-      'user' => 'george',
-      'stat' => 'attack1',
-      'stat' => 'attack2',
-      'stat' => 'attack3',
-      'stat' => 'attack4',
-      'stat' => 'attack5',
-      'stat' => 'attack6'
-    }
-    d.emit(message, get_time)
-    d.run
-
-    assert_equal :lpush, $command
-    assert_equal "attack6", $key
-    assert_equal message, $message
-    assert_equal 3, d.instance.value_length
-  end
 
 
   def test_set
@@ -336,36 +310,6 @@ class RedisStoreOutputTest < Test::Unit::TestCase
     assert_equal "george", $key
     assert_equal 81, $score
     assert_equal message, $message
-  end
-
-  def test_zset_desc_with_limitation
-    config = %[
-      format_type plain
-      store_type zset
-      key_path   user
-      score_path result
-      value_length 4
-      order desc
-    ]
-
-    d = create_driver(config)
-    message = {
-      'user' => 'george',
-      'stat' => { 'attack' => 7 },
-      'result' => 81,
-      'result' => 101,
-      'result' => 102,
-      'result' => 103,
-      'result' => 104
-    }
-    d.emit(message, get_time)
-    d.run
-
-    assert_equal :zadd, $command
-    assert_equal "george", $key
-    assert_equal 104, $score
-    assert_equal message, $message
-    assert_equal 4, d.instance.value_length
   end
 
   def test_zset_with_no_score_path


### PR DESCRIPTION
Hi, thanks for useful fluentd plugin for Redis.
I want to use this library, but I could not use because the eval methods does not work well.
This method seem to be converted as private method, so this library seems to be fixed I think.
Moreover, I have a suggestion that original source generates Redis script, but I think this script could write
as "Ruby scripts". So in this pull request, I rewrite as two methods as Ruby script.
I hope my pull request will help your library.
 