### PR TITLE
Added a parameter to control the flush interval in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Configuration
 | `store_type`  | string | zset                     | `string`/`list`/`set`/`zset`/`publish`               |
 | `format_type` | string | plain                    | format type for _value_ (`plain`/`json`/`msgpack`)   |
 | `key_expire`  | int    | -1                       | If set, the key will be expired in specified seconds |
+| `flush_interval`  | int    | 1                       | Time interval which events will be flushed to Redis |
 
 Note: either `key` or `key_path` is required.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Configuration
 | `store_type`  | string | zset                     | `string`/`list`/`set`/`zset`/`publish`               |
 | `format_type` | string | plain                    | format type for _value_ (`plain`/`json`/`msgpack`)   |
 | `key_expire`  | int    | -1                       | If set, the key will be expired in specified seconds |
-| `flush_interval`  | int    | 1                       | Time interval which events will be flushed to Redis |
+| `flush_interval`  | time    | 1                       | Time interval which events will be flushed to Redis |
 
 Note: either `key` or `key_path` is required.
 

--- a/lib/fluent/plugin/out_redis_store.rb
+++ b/lib/fluent/plugin/out_redis_store.rb
@@ -23,7 +23,7 @@ module Fluent
     config_param :value_expire,   :integer, :default => -1
     config_param :value_length,   :integer, :default => -1
     config_param :order,          :string,  :default => 'asc'
-    config_param :flush_interval, :time, :default => 1
+    config_set_default :flush_interval, 1
 
     def initialize
       super

--- a/lib/fluent/plugin/out_redis_store.rb
+++ b/lib/fluent/plugin/out_redis_store.rb
@@ -23,7 +23,7 @@ module Fluent
     config_param :value_expire,   :integer, :default => -1
     config_param :value_length,   :integer, :default => -1
     config_param :order,          :string,  :default => 'asc'
-    config_param :flush_interval, :integer, :default => 1
+    config_param :flush_interval, :time, :default => 1
 
     def initialize
       super

--- a/lib/fluent/plugin/out_redis_store.rb
+++ b/lib/fluent/plugin/out_redis_store.rb
@@ -11,18 +11,19 @@ module Fluent
     config_param :timeout,   :float,   :default => 5.0
 
     # redis command and parameters
-    config_param :format_type,  :string,  :default => 'json'
-    config_param :store_type,   :string,  :default => 'zset'
-    config_param :key_prefix,   :string,  :default => ''
-    config_param :key_suffix,   :string,  :default => ''
-    config_param :key,          :string,  :default => nil
-    config_param :key_path,     :string,  :default => nil
-    config_param :score_path,   :string,  :default => nil
-    config_param :value_path,   :string,  :default => ''
-    config_param :key_expire,   :integer, :default => -1
-    config_param :value_expire, :integer, :default => -1
-    config_param :value_length, :integer, :default => -1
-    config_param :order,        :string,  :default => 'asc'
+    config_param :format_type,    :string,  :default => 'json'
+    config_param :store_type,     :string,  :default => 'zset'
+    config_param :key_prefix,     :string,  :default => ''
+    config_param :key_suffix,     :string,  :default => ''
+    config_param :key,            :string,  :default => nil
+    config_param :key_path,       :string,  :default => nil
+    config_param :score_path,     :string,  :default => nil
+    config_param :value_path,     :string,  :default => ''
+    config_param :key_expire,     :integer, :default => -1
+    config_param :value_expire,   :integer, :default => -1
+    config_param :value_length,   :integer, :default => -1
+    config_param :order,          :string,  :default => 'asc'
+    config_param :flush_interval, :integer, :default => 1
 
     def initialize
       super


### PR DESCRIPTION
The default flush interval of 60 seconds, inherited from the BufferedOutput class,
is now 1 second and can be specified in the configuration file.