### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-redis-store.gemspec
+++ b/fluent-plugin-redis-store.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
 
     gem.add_development_dependency "rake"
     gem.add_development_dependency "test-unit"
-    gem.add_runtime_dependency "fluentd"
+    gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
     gem.add_runtime_dependency "redis"
 end

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -12,6 +12,8 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|
@@ -25,4 +27,5 @@ end
 require 'fluent/plugin/out_redis_store'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end

--- a/test/plugin/test_out_redis_publish.rb
+++ b/test/plugin/test_out_redis_publish.rb
@@ -65,7 +65,7 @@ class RedisStoreOutputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::RedisStoreOutput).configure(conf)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::RedisStoreOutput).configure(conf)
   end
 
   def test_configure_defaults
@@ -134,16 +134,17 @@ class RedisStoreOutputTest < Test::Unit::TestCase
 #  def test_write
 #    d = create_driver(CONFIG1)
 #
-#    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-#    d.emit({ "foo" => "bar" }, time)
-#    d.run
+#    time = event_time("2011-01-02 13:14:15 UTC")
+#    d.run(default_tag 'test') do
+#      d.feed({ "foo" => "bar" }, time)
+#    end
 #
 #    assert_equal "test", $channel
 #    assert_equal(%Q[{"foo":"bar","time":#{time}}], $message)
 #  end
 
   def get_time
-    Time.parse("2011-01-02 13:14:15 UTC").to_i
+    event_time("2011-01-02 13:14:15 UTC")
   end
 
   # it should return whole message
@@ -159,8 +160,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'stat' => { 'attack' => 7 }
     }
     $ttl = nil
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal "george", $key
     assert_equal message, $message
@@ -181,8 +183,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'stat' => { 'attack' => 7 }
     }
     $ttl = nil
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal "george", $key
     assert_equal 7, $message
@@ -201,8 +204,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'stat' => { 'attack' => 7 }
     }
     $ttl = nil
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal "george", $key
     assert_equal message.to_json, $message
@@ -220,8 +224,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'stat' => { 'attack' => 7 }
     }
     $ttl = nil
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal "george", $key
     assert_equal message.to_msgpack, $message
@@ -238,8 +243,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'user' => 'george',
       'stat' => { 'attack' => 7 }
     }
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal :rpush, $command
     assert_equal "george", $key
@@ -258,8 +264,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'user' => 'george',
       'stat' => { 'attack' => 7 }
     }
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal :lpush, $command
     assert_equal "george", $key
@@ -278,8 +285,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'user' => 'george',
       'stat' => { 'attack' => 7 }
     }
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal :sadd, $command
     assert_equal "george", $key
@@ -300,8 +308,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'stat' => { 'attack' => 7 },
       'result' => 81
     }
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal :zadd, $command
     assert_equal "george", $key
@@ -322,8 +331,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
       'stat' => { 'attack' => 7 },
       'result' => 81
     }
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal :zadd, $command
     assert_equal "george", $key
@@ -342,8 +352,9 @@ class RedisStoreOutputTest < Test::Unit::TestCase
     message = {
       'user' => 'george'
     }
-    d.emit(message, get_time)
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(get_time, message)
+    end
 
     assert_equal :publish, $command
     assert_equal "george", $channel
@@ -359,9 +370,10 @@ class RedisStoreOutputTest < Test::Unit::TestCase
 
     d = create_driver(config)
     message = { 'user' => 'george' }
-    d.emit(message, get_time)
     assert_raise(Fluent::ConfigError) do
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(get_time, message)
+      end
     end
   end
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
In v0.14, Fluentd users will be able to switch non-buffered/buffered plugin by plugin configure.
Because v0.14 Output Plugin API is integrated in Fluent::Plugin::Output class.
We can choose this behavior with prefer_buffered_processing, process, and write APIs.

This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.