### PR TITLE
Use YAJL library to serialize JSON

### DIFF
--- a/lib/fluent/plugin/out_redis_store.rb
+++ b/lib/fluent/plugin/out_redis_store.rb
@@ -237,7 +237,7 @@ module Fluent::Plugin
       value = traverse(record, @value_path)
       case @format_type
       when 'json'
-        value.to_json
+        Yajl.dump(value)
       when 'msgpack'
         value.to_msgpack
       else


### PR DESCRIPTION
In my use case, I may receive invalid utf-8 characters in log data. Currently when this happens, it jams the pipeline:

```
2018-04-05 10:02:36 +0000 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2018-04-05 10:02:37 +0000 chunk="5691709ebf589cc353a6ce50f210dbaf" error_class=JSON::GeneratorError error="source sequence is illegal/malformed utf-8"\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluent-plugin-redis-store-0.2.0/lib/fluent/plugin/out_redis_store.rb:240:in `to_json'\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluent-plugin-redis-store-0.2.0/lib/fluent/plugin/out_redis_store.rb:240:in `get_value_from'\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluent-plugin-redis-store-0.2.0/lib/fluent/plugin/out_redis_store.rb:118:in `operation_for_zset'\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluent-plugin-redis-store-0.2.0/lib/fluent/plugin/out_redis_store.rb:91:in `block (3 levels) in write'\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluent-plugin-redis-store-0.2.0/lib/fluent/plugin/out_redis_store.rb:86:in `each'\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluent-plugin-redis-store-0.2.0/lib/fluent/plugin/out_redis_store.rb:86:in `block (2 levels) in write'\
  2018-04-05 10:02:36 +0000 [warn]: #0 /usr/lib/ruby/gems/2.3.0/gems/fluentd-1.0.2/lib/fluent/plugin/buffer/memory_chunk.rb:80:in `open'\
  ...
```

I noticed that other plugins, including those shipped with fluentd get around this by using YAJL:
- fluentd json formatter: https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/formatter_json.rb
- s3 output plugin: https://github.com/fluent/fluent-plugin-s3/commit/8d4c3a2214cd5f8a00c14eb30885237da46f7f03
- Elasticsearch output plugin: https://github.com/uken/fluent-plugin-elasticsearch/commit/c6b91cd36b4ac58f691a200d29a146c571f545ee